### PR TITLE
Black Duck: Upgrade commons-beanutils to version 1.9.4-talend fix known security vulerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf8'?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
@@ -14,7 +14,7 @@
   <scm>
     <connection>scm:git:git://github.com/blackducksoftware/hub-common.git/</connection>
     <developerConnection>scm:git:git@github.com:BlackDuckCoPilot/example-maven-travis.git</developerConnection>
-    <url>https://github.com/BlackDuckCoPilot/example-maven-travid</url>
+    <url>https://github.com/BlackDuckCoPilot/example-maven-travis</url>
   </scm>
 
   <properties>
@@ -76,7 +76,7 @@
     <dependency>
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
-      <version>1.9.0</version>
+      <version>1.9.4-talend</version>
     </dependency>
     <dependency>
       <groupId>commons-collections</groupId>


### PR DESCRIPTION

# Synopsys Black Duck Auto Pull Request
Upgrade commons-beanutils from version 1.9.0 to 1.9.4-talend in order to fix security vulnerabilities:

The direct dependency commons-beanutils/1.9.0 has 2 vulnerabilities (max score 9.1).


| Parent | Child Component | Vulnerability | Score |  Policy | Description | Current Ver |
| --- | --- | --- | --- | --- | --- | --- |
| / | commons-beanutils/1.9.0 | <a href="https://poc39.blackduck.synopsys.com/api/vulnerabilities/BDSA-2014-0001/overview" target="_blank">BDSA-2014-0001</a> | <span style="color:DarkRed">9.1</span> | Vulnerability Score Greater Than Or Equal to 6 | The Struts 1 ActionForm object allowed access to the `class` parameter, which is directly mapped to the `getClass()` method. A remote attacker could use this flaw to manipulate the `ClassLoader` used  | 1.9.0 |
| / | commons-beanutils/1.9.0 | <a href="https://poc39.blackduck.synopsys.com/api/vulnerabilities/BDSA-2014-0129/overview" target="_blank">BDSA-2014-0129</a> | <span style="color:DarkRed">9.1</span> | Vulnerability Score Greater Than Or Equal to 6 | Apache Commons BeanUtils introduced a fix for BDSA-2014-0001 (CVE-2014-0114), however did not enable the protections by default. A remote attacker could leverage this to cause code execution in applic | 1.9.0 |


