### PR TITLE
Black Duck: Upgrade httpclient to version 4.5.13-talend fix known security vulerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf8'?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
@@ -14,7 +14,7 @@
   <scm>
     <connection>scm:git:git://github.com/blackducksoftware/hub-common.git/</connection>
     <developerConnection>scm:git:git@github.com:BlackDuckCoPilot/example-maven-travis.git</developerConnection>
-    <url>https://github.com/BlackDuckCoPilot/example-maven-travid</url>
+    <url>https://github.com/BlackDuckCoPilot/example-maven-travis</url>
   </scm>
 
   <properties>
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.3.5</version>
+      <version>4.5.13-talend</version>
     </dependency>
     <dependency>
       <groupId>commons-net</groupId>


### PR DESCRIPTION

# Synopsys Black Duck Auto Pull Request
Upgrade httpclient from version 4.3.5 to 4.5.13-talend in order to fix security vulnerabilities:

The direct dependency httpclient/4.3.5 has 1 vulnerabilities (max score 6.5).


| Parent | Child Component | Vulnerability | Score |  Policy | Description | Current Ver |
| --- | --- | --- | --- | --- | --- | --- |
| / | httpclient/4.3.5 | <a href="https://poc39.blackduck.synopsys.com/api/vulnerabilities/BDSA-2015-0651/overview" target="_blank">BDSA-2015-0651</a> | <span style="color:Orange">6.5</span> | Vulnerability Score Greater Than Or Equal to 6 | Apache HttpComponents HttpClient is vulnerable to ignoring a socket timeout option during an SSL handshake. A remote attacker could leverage this to cause a denial-of-service (DoS)). | 4.3.5 |


