### PR TITLE
Black Duck: Upgrade spring-context to version 4.3.30.RELEASE fix known security vulerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf8'?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
@@ -14,7 +14,7 @@
   <scm>
     <connection>scm:git:git://github.com/blackducksoftware/hub-common.git/</connection>
     <developerConnection>scm:git:git@github.com:BlackDuckCoPilot/example-maven-travis.git</developerConnection>
-    <url>https://github.com/BlackDuckCoPilot/example-maven-travid</url>
+    <url>https://github.com/BlackDuckCoPilot/example-maven-travis</url>
   </scm>
 
   <properties>
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
-      <version>4.2.5.RELEASE</version>
+      <version>4.3.30.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>commons-logging</groupId>


### PR DESCRIPTION

# Synopsys Black Duck Auto Pull Request
Upgrade spring-context from version 4.2.5.RELEASE to 4.3.30.RELEASE in order to fix security vulnerabilities:

The direct dependency spring-context/4.2.5.RELEASE has 7 vulnerabilities (max score 8.8).


| Parent | Child Component | Vulnerability | Score |  Policy | Description | Current Ver |
| --- | --- | --- | --- | --- | --- | --- |
| / | spring-context/4.2.5.RELEASE | <a href="https://poc39.blackduck.synopsys.com/api/vulnerabilities/BDSA-2018-0994/overview" target="_blank">BDSA-2018-0994</a> | <span style="color:Red">8.8</span> | Vulnerability Score Greater Than Or Equal to 6 | Spring Framework is vulnerable to remote code execution (*RCE*) due to lack of proper validation of user-supplied input. Potential attackers can leverage this flaw to run arbitrary code on the target  | 4.2.5.RELEASE |
| / | spring-context/4.2.5.RELEASE | <a href="https://poc39.blackduck.synopsys.com/api/vulnerabilities/BDSA-2018-1042/overview" target="_blank">BDSA-2018-1042</a> | <span style="color:Red">8.5</span> | Vulnerability Score Greater Than Or Equal to 6 | Spring Framework is vulnerable to remote code execution (*RCE*) due to lack of proper validation of user-supplied input. Potential attackers can leverage this flaw to run arbitrary code on the target  | 4.2.5.RELEASE |
| / | spring-context/4.2.5.RELEASE | <a href="https://poc39.blackduck.synopsys.com/api/vulnerabilities/BDSA-2016-0002/overview" target="_blank">BDSA-2016-0002</a> | <span style="color:Red">8.1</span> | Vulnerability Score Greater Than Or Equal to 6 | In multiple versions of Spring Framework, paths provided to the `Resourceservlet` were not properly sanitized and as a result exposed to directory traversal attacks. `ResourceServlet` is now depreciat | 4.2.5.RELEASE |
| / | spring-context/4.2.5.RELEASE | <a href="https://poc39.blackduck.synopsys.com/api/vulnerabilities/BDSA-2016-1700/overview" target="_blank">BDSA-2016-1700</a> | <span style="color:Red">7.3</span> | Vulnerability Score Greater Than Or Equal to 6 | Pivotal's Spring Framework contains an unsafe Java deserialization vulnerability. If the Spring Framework library's `HttpInvokerServiceExporter` is being used to deserialize client data, it may be pos | 4.2.5.RELEASE |
| / | spring-context/4.2.5.RELEASE | <a href="https://poc39.blackduck.synopsys.com/api/vulnerabilities/BDSA-2018-1013/overview" target="_blank">BDSA-2018-1013</a> | <span style="color:Orange">6.7</span> | Vulnerability Score Greater Than Or Equal to 6 | Spring Framework is vulnerable to directory traversal due to the way static content can be loaded. Potential attackers could leverage this flaw to gain unauthorized access to sensitive files on Window | 4.2.5.RELEASE |
| / | spring-context/4.2.5.RELEASE | <a href="https://poc39.blackduck.synopsys.com/api/vulnerabilities/BDSA-2018-1440/overview" target="_blank">BDSA-2018-1440</a> | <span style="color:Orange">6.7</span> | Vulnerability Score Greater Than Or Equal to 6 | Spring Framework has a flaw in the manipulation of regular expressions within the spring-messaging module. An attacker can send a specially crafted message to the simple STOMP broker that will trigger | 4.2.5.RELEASE |
| / | spring-context/4.2.5.RELEASE | <a href="https://poc39.blackduck.synopsys.com/api/vulnerabilities/BDSA-2020-2431/overview" target="_blank">BDSA-2020-2431</a> | <span style="color:Orange">6.7</span> | Vulnerability Score Greater Than Or Equal to 6 | It was discovered that Spring Framework was vulnerable to RFD protection bypass. In some instances, depending on the browser used, an attacker could bypass the RFD attack protections via the use of a  | 4.2.5.RELEASE |


