### PR TITLE
Black Duck: Upgrade poi to version 3.17 fix known security vulerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf8'?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
@@ -14,7 +14,7 @@
   <scm>
     <connection>scm:git:git://github.com/blackducksoftware/hub-common.git/</connection>
     <developerConnection>scm:git:git@github.com:BlackDuckCoPilot/example-maven-travis.git</developerConnection>
-    <url>https://github.com/BlackDuckCoPilot/example-maven-travid</url>
+    <url>https://github.com/BlackDuckCoPilot/example-maven-travis</url>
   </scm>
 
   <properties>
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>org.apache.poi</groupId>
       <artifactId>poi</artifactId>
-      <version>3.6</version>
+      <version>3.17</version>
     </dependency>
     <dependency>
       <groupId>commons-beanutils</groupId>


### PR DESCRIPTION

# Synopsys Black Duck Auto Pull Request
Upgrade poi from version 3.6 to 3.17 in order to fix security vulnerabilities:

The direct dependency poi/3.6 has 3 vulnerabilities (max score 6.5) and 3 vulnerabilities in child dependencies (max score 9.4).


| Parent | Child Component | Vulnerability | Score |  Policy | Description | Current Ver |
| --- | --- | --- | --- | --- | --- | --- |
| / | poi/3.6 | <a href="https://poc39.blackduck.synopsys.com/api/vulnerabilities/BDSA-2013-0047/overview" target="_blank">BDSA-2013-0047</a> | <span style="color:Orange">6.5</span> | Vulnerability Score Greater Than Or Equal to 6 | Apache POI is vulnerable to a denial-of-service. An attacker can exploit this vulnerability by sending a crafted Channel Definition Format (CDF) or Compound File Binary Format (CFBF) document to Apach | 3.6 |
| / | poi/3.6 | <a href="https://poc39.blackduck.synopsys.com/api/vulnerabilities/BDSA-2019-3341/overview" target="_blank">BDSA-2019-3341</a> | <span style="color:Orange">6.5</span> | Vulnerability Score Greater Than Or Equal to 6 | Apache is vulnerable to XML External Entity (XXE) injection due to the unsafe processing of client-provided input documents. An attacker could read files from the local file system, or from internal n | 3.6 |
| / | poi/3.6 | <a href="https://poc39.blackduck.synopsys.com/api/vulnerabilities/BDSA-2017-0681/overview" target="_blank">BDSA-2017-0681</a> | <span style="color:Orange">6.4</span> | Vulnerability Score Greater Than Or Equal to 6 | Apache POI (Poor Obfuscation Implementation) in versions prior to release **3.15** allow remote attackers to cause a Denial of Service (CPU consumption) via a specially crafted Open Office XML file,   | 3.6 |
| poi/3.6 | log4j/1.2.13 | <a href="https://poc39.blackduck.synopsys.com/api/vulnerabilities/BDSA-2017-0180/overview" target="_blank">BDSA-2017-0180</a> | <span style="color:DarkRed">9.4</span> | Vulnerability Score Greater Than Or Equal to 6 | A deserialization flaw in log4j can lead to remote arbitrary code execution. | 1.2.13 |
| poi/3.6 | log4j/1.2.13 | <a href="https://poc39.blackduck.synopsys.com/api/vulnerabilities/BDSA-2019-4008/overview" target="_blank">BDSA-2019-4008</a> | <span style="color:Red">9.0</span> | Vulnerability Score Greater Than Or Equal to 6 | Apache Log4j is vulnerable to remote code execution (RCE).  This allows a remote attacker to send a crafted serialized payload that, when processed by Log4j, will execute arbitrary code. This can occu | 1.2.13 |
| poi/3.6 | log4j/1.2.13 | <a href="https://poc39.blackduck.synopsys.com/api/vulnerabilities/BDSA-2021-3764/overview" target="_blank">BDSA-2021-3764</a> | <span style="color:Red">7.2</span> | Vulnerability Score Greater Than Or Equal to 6 | Log4j **1.x** versions are vulnerable to deserializing untrusted data if configured to use `JMSAppender` (which is not the default). A remote attacker could leverage this to execute arbitrary code on  | 1.2.13 |


