### PR TITLE
Black Duck: Upgrade commons-collections to version 2.0 fix known security vulerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf8'?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
@@ -14,7 +14,7 @@
   <scm>
     <connection>scm:git:git://github.com/blackducksoftware/hub-common.git/</connection>
     <developerConnection>scm:git:git@github.com:BlackDuckCoPilot/example-maven-travis.git</developerConnection>
-    <url>https://github.com/BlackDuckCoPilot/example-maven-travid</url>
+    <url>https://github.com/BlackDuckCoPilot/example-maven-travis</url>
   </scm>
 
   <properties>
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
-      <version>1.0</version>
+      <version>2.0</version>
     </dependency>
     <dependency>
       <groupId>commons-fileupload</groupId>


### PR DESCRIPTION

# Synopsys Black Duck Auto Pull Request
Upgrade commons-collections from version 1.0 to 2.0 in order to fix security vulnerabilities:

The direct dependency commons-collections/1.0 has 2 vulnerabilities (max score 9.8).


| Parent | Child Component | Vulnerability | Score |  Policy | Description | Current Ver |
| --- | --- | --- | --- | --- | --- | --- |
| / | commons-collections/1.0 | <a href="https://poc39.blackduck.synopsys.com/api/vulnerabilities/CVE-2017-15708/overview" target="_blank">CVE-2017-15708</a> | <span style="color:DarkRed">9.8</span> | Vulnerability Score Greater Than Or Equal to 6 | In Apache Synapse, by default no authentication is required for Java Remote Method Invocation (RMI). So Apache Synapse 3.0.1 or all previous releases (3.0.0, 2.1.0, 2.0.0, 1.2, 1.1.2, 1.1.1) allows re | 1.0 |
| / | commons-collections/1.0 | <a href="https://poc39.blackduck.synopsys.com/api/vulnerabilities/CVE-2015-6420/overview" target="_blank">CVE-2015-6420</a> | <span style="color:Red">7.5</span> | Vulnerability Score Greater Than Or Equal to 6 | Serialized-object interfaces in certain Cisco Collaboration and Social Media; Endpoint Clients and Client Software; Network Application, Service, and Acceleration; Network and Content Security Devices | 1.0 |


