### PR TITLE
Black Duck: Upgrade commons-fileupload to version 1.4 fix known security vulerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf8'?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
@@ -14,7 +14,7 @@
   <scm>
     <connection>scm:git:git://github.com/blackducksoftware/hub-common.git/</connection>
     <developerConnection>scm:git:git@github.com:BlackDuckCoPilot/example-maven-travis.git</developerConnection>
-    <url>https://github.com/BlackDuckCoPilot/example-maven-travid</url>
+    <url>https://github.com/BlackDuckCoPilot/example-maven-travis</url>
   </scm>
 
   <properties>
@@ -86,7 +86,7 @@
     <dependency>
       <groupId>commons-fileupload</groupId>
       <artifactId>commons-fileupload</artifactId>
-      <version>1.2.1</version>
+      <version>1.4</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION

# Synopsys Black Duck Auto Pull Request
Upgrade commons-fileupload from version 1.2.1 to 1.4 in order to fix security vulnerabilities:

The direct dependency commons-fileupload/1.2.1 has 4 vulnerabilities (max score 9.4).


| Parent | Child Component | Vulnerability | Score |  Policy | Description | Current Ver |
| --- | --- | --- | --- | --- | --- | --- |
| / | commons-fileupload/1.2.1 | <a href="https://poc39.blackduck.synopsys.com/api/vulnerabilities/BDSA-2013-0013/overview" target="_blank">BDSA-2013-0013</a> | <span style="color:DarkRed">9.4</span> | Vulnerability Score Greater Than Or Equal to 6 | Apache Commons FileUpload was discovered to be vulnerable to NULL byte poisoning due to the incorrect handling of filenames containing NULL bytes. The failure to check for NULL byte allows a remote un | 1.2.1 |
| / | commons-fileupload/1.2.1 | <a href="https://poc39.blackduck.synopsys.com/api/vulnerabilities/BDSA-2016-1573/overview" target="_blank">BDSA-2016-1573</a> | <span style="color:Red">8.4</span> | Vulnerability Score Greater Than Or Equal to 6 | Apache Commons FileUpload is vulnerable to remote code execution (RCE) due to unsafe deserialization of Java objects. This could allow an attacker to write, copy and delete arbitrary files on a target | 1.2.1 |
| / | commons-fileupload/1.2.1 | <a href="https://poc39.blackduck.synopsys.com/api/vulnerabilities/BDSA-2014-0102/overview" target="_blank">BDSA-2014-0102</a> | <span style="color:Orange">6.7</span> | Vulnerability Score Greater Than Or Equal to 6 | Apache Commons File-Upload contains a denial-of-service (DoS) flaw. This could allow a remote attacker to supply a specially crafted content-type, which upon being received by the component, triggers  | 1.2.1 |
| / | commons-fileupload/1.2.1 | <a href="https://poc39.blackduck.synopsys.com/api/vulnerabilities/BDSA-2016-1636/overview" target="_blank">BDSA-2016-1636</a> | <span style="color:Orange">6.7</span> | Vulnerability Score Greater Than Or Equal to 6 | Apache Commons FileUpload is vulnerable to denial-of-service (DoS) attacks due to miscalculated buffer size. | 1.2.1 |


